### PR TITLE
corrigido explode se no caminho houver pasta com - no meio

### DIFF
--- a/app/Dados.php
+++ b/app/Dados.php
@@ -31,7 +31,8 @@ class Dados
                 //resumo *-resNFe.xml
                 //cancelamento *-cancNFe.xml
                 //carta de correção *-cce.xml
-                $pos = explode('-', $file);
+                $tmp = explode('/', $file);
+                $pos = explode('-',end($tmp));
                 $dom = new Dom();
                 $dom->loadXMLFile($file);
                 switch ($pos[1]) {


### PR DESCRIPTION
Eu estava tentando rodar a aplicação teste mas como minha pasta ficou com o nome ../nfe-php/.., o comando explode tava entendendo errado as partes do array. Então explodindo primeiro pelo caminho do arquivo e depois pelo nome com o traço deu certo.
